### PR TITLE
Use text properties for inserting suggestions

### DIFF
--- a/psc-ide-flycheck.el
+++ b/psc-ide-flycheck.el
@@ -4,7 +4,8 @@
 
 ;; Author: Brian Sermons
 ;;         Bodil Stokke <bodil@bodil.org>
-;; Package-Requires: ((flycheck "0.24") (emacs "24.4"))
+;; Package-Requires: ((flycheck "0.24") (emacs "24.4") (let-alist "1.0.4") (psc-ide "0.1.0") (dash "2.12.0") (seq "1.11"))
+;; Version: 0.1
 ;; URL: https://github.com/epost/psc-ide-emacs
 
 ;; This file is not part of GNU Emacs.
@@ -24,8 +25,10 @@
 
 ;;; Commentary:
 
-;;; Usage: (eval-after-load 'flycheck
-;;;          '(add-hook 'flycheck-mode-hook #'psc-ide-flycheck-setup))
+;; Usage:
+;;
+;;     (eval-after-load 'flycheck
+;;       '(add-hook 'flycheck-mode-hook #'psc-ide-flycheck-setup))
 
 ;;; Code:
 

--- a/psc-ide-flycheck.el
+++ b/psc-ide-flycheck.el
@@ -29,8 +29,13 @@
 
 ;;; Code:
 
-(require 'cl-lib)
+(eval-when-compile
+  (require 'cl-lib)
+  (require 'let-alist))
+
+(require 'seq)
 (require 'json)
+(require 'dash)
 (require 'flycheck)
 (require 'psc-ide-protocol)
 
@@ -40,87 +45,60 @@
   :tag "Flycheck PscIde Ignored Error Codes"
   :type '(repeat string))
 
-(defun psc-ide-flycheck-decode-purescript-error (checker type error)
-  (let* ((position (assoc 'position error))
-         (error-code (cdr (assoc 'errorCode error)))
-         ;; (end-line (cdr (assoc 'endLine position)))
-         ;; (end-col (cdr (assoc 'endColumn position)))
-         (err-msg (cdr (assoc 'message error)))
-         (filename (cdr (assoc 'filename error)))
-         (start-line (or (cdr (assoc 'startLine position)) 1))
-         (start-col (or (cdr (assoc 'startColumn position)) 1)))
-    (when (not (-contains? psc-ide-flycheck-ignored-error-codes error-code))
-      (flycheck-error-new-at start-line
-                             start-col
-                             type
-                             err-msg
-                             :id (concat filename
-                                         ":" (number-to-string start-line)
-                                         ":" (number-to-string start-col))
-                             :checker checker))))
-
-(defun psc-ide-flycheck-read-json (str)
-  (let* ((json-array-type 'list))
-    (condition-case nil
-        (json-read-from-string str)
-      (error nil))))
-
 (defun psc-ide-flycheck-parse-errors (data checker)
-  "Decode purescript json output errors."
-  (let* ((resultType (pcase (cdr (assoc 'resultType data))
-                         (`success 'warning)
-                         (_ 'error)))
-         (result (cdr (assoc 'result data)))
-         (errors (-filter #'identity
-                          (mapcar
-                           (lambda (x) (psc-ide-flycheck-decode-purescript-error checker resultType x))
-                           result))))
-         errors))
+  "Decode purescript json output errors from DATA with CHECKER."
+  (let (errors)
+    (let-alist data
+      (seq-do (lambda (err)
+                (let-alist err
+                  (unless (member .errorCode psc-ide-flycheck-ignored-error-codes)
+                    (put-text-property 0 1 :suggestion .suggestion .errorCode)
+                    (put-text-property 0 1 :end-line   .position.endLine .errorCode)
+                    (put-text-property 0 1 :end-column .position.endColumn .errorCode)
+                    (when .suggestion
+                      (setq .message (concat .message " ●")))
+                    (push (flycheck-error-new-at
+                           .position.startLine
+                           .position.startColumn
+                           'error
+                           .message
+                           :id .errorCode
+                           :checker checker
+                           :filename .filename)
+                          errors))))
+              .result))
+    errors))
 
-(defun psc-ide-flycheck-save-suggestions (errs)
-  (setq-local
-   psc-ide-flycheck-suggestions
-   (-map
-    (lambda (err)
-      (let* ((err-filename (cdr (assoc 'filename err)))
-             (err-position (cdr (assoc 'position err)))
-             (err-line (cdr (assoc 'startLine err-position)))
-             (err-column (cdr (assoc 'startColumn err-position)))
-             (err-id (concat err-filename ":" (number-to-string err-line)
-                             ":" (number-to-string err-column))))
-        (cons err-id err)))
-    (-filter (lambda (i) (and (cdr (assoc 'position i))
-                              (cdr (assoc 'suggestion i))))
-             errs))))
-
+;;;###autoload
 (defun psc-ide-flycheck-insert-suggestion ()
+  "Replace error with suggestion from psc compiler."
   (interactive)
-  (let* ((id (flycheck-error-id (car (flycheck-overlay-errors-at (point)))))
-          (err (cdr (assoc id psc-ide-flycheck-suggestions)))
-          (pos (cdr (assoc 'position err)))
-          (sugg (cdr (assoc 'suggestion err))))
-    (if (and pos sugg)
-        (let* ((start (save-excursion
-                        (goto-char (point-min))
-                        (forward-line (- (cdr (assoc 'startLine pos)) 1))
-                        (move-to-column (- (cdr (assoc 'startColumn pos)) 1))
-                        (point)))
-                (end (save-excursion
+  (-if-let* ((flycheck-err (car (flycheck-overlay-errors-at (point))))
+             (suggestion   (get-text-property 0 :suggestion (flycheck-error-id flycheck-err)))
+             (end-line     (get-text-property 0 :end-line   (flycheck-error-id flycheck-err)))
+             (end-column   (get-text-property 0 :end-column (flycheck-error-id flycheck-err))))
+      (let* ((start (save-excursion
                       (goto-char (point-min))
-                      (forward-line (- (cdr (assoc 'endLine pos)) 1))
-                      (move-to-column (- (cdr (assoc 'endColumn pos)) 1))
-                      (point))))
-          (progn
-            (kill-region start end)
-            (goto-char start)
-            (let ((new-end
-                    (save-excursion
-                      (insert (cdr (assoc 'replacement sugg)))
-                      (point))))
-              (set-mark start)
-              (goto-char new-end)
-              (setq deactivate-mark nil))))
-      (message "No suggestion available!"))))
+                      (forward-line (- (flycheck-error-line flycheck-err) 1))
+                      (move-to-column (- (flycheck-error-column flycheck-err) 1))
+                      (point)))
+             (end (save-excursion
+                    (goto-char (point-min))
+                    (forward-line (- end-line 1))
+                    (move-to-column (- end-column 1))
+                    (point))))
+        (progn
+          (kill-region start end)
+          (goto-char start)
+          (let ((new-end
+                 (save-excursion
+                   (let-alist suggestion
+                     (insert .replacement))
+                   (point))))
+            (set-mark start)
+            (goto-char new-end)
+            (deactivate-mark))))
+    (message "No suggestion available")))
 
 (define-key purescript-mode-map (kbd "C-c M-s")
   'psc-ide-flycheck-insert-suggestion)
@@ -132,10 +110,8 @@ CALLBACK is the status callback passed by flycheck."
   (psc-ide-send (psc-ide-command-rebuild)
                 (lambda (result)
                   (condition-case err
-                      (progn
-                        (psc-ide-flycheck-save-suggestions (append (cdr (assoc 'result result)) nil))
-                        (let ((errors (psc-ide-flycheck-parse-errors result checker)))
-                          (funcall callback 'finished errors)))
+                      (let ((errors (psc-ide-flycheck-parse-errors result checker)))
+                        (funcall callback 'finished errors))
                     (`(error debug)
                      (funcall callback 'errored (error-message-string err)))))))
 


### PR DESCRIPTION
Instead of using a local var `psc-ide-flycheck-suggestions` this change allows to store the suggestions in flycheck-error id string as properties.

should this package named `flycheck-psc-ide.el`?
